### PR TITLE
[FEAT] 변환된 텍스트 수어를 db에 저장

### DIFF
--- a/src/main/java/npng/handdoc/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/npng/handdoc/diagnosis/controller/DiagnosisController.java
@@ -2,8 +2,10 @@ package npng.handdoc.diagnosis.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import npng.handdoc.diagnosis.domain.Diagnosis;
+import npng.handdoc.diagnosis.dto.request.SignLogReq;
 import npng.handdoc.diagnosis.dto.response.StartDiagnosisRes;
 import npng.handdoc.diagnosis.service.DiagnosisService;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +32,13 @@ public class DiagnosisController {
     @Operation(summary = "진료 세션 종료 API", description = "진료 종료 버튼을 눌렀을 때 호출하는 API입니다. 진료 Id를 입력해주세요.")
     public ResponseEntity<Object> end(@PathVariable String diagnosisId){
         diagnosisService.endDiagnosis(diagnosisId);
+        return ResponseEntity.ok(EMPTY_RESPONSE);
+    }
+
+    @PostMapping("/{diagnosisId}/sign")
+    @Operation(summary = "텍스트로 변환된 수어 저장 API", description = "환자의 전송 버튼 클릭시 호출하는 API입니다. 진료 Id를 입력해주세요.")
+    public ResponseEntity<Object> sign(@PathVariable String diagnosisId, @Valid @RequestBody SignLogReq request){
+        diagnosisService.saveSignText(diagnosisId,request);
         return ResponseEntity.ok(EMPTY_RESPONSE);
     }
 }

--- a/src/main/java/npng/handdoc/diagnosis/domain/Diagnosis.java
+++ b/src/main/java/npng/handdoc/diagnosis/domain/Diagnosis.java
@@ -27,6 +27,7 @@ public class Diagnosis extends BaseDocument {
     @Builder.Default
     private DiagnosisStatus status = DiagnosisStatus.ACTIVE;
 
+    @Builder.Default
     private List<ChatLog> chatLogList = new ArrayList<>();
 
     @Indexed(name = "expiredAt")

--- a/src/main/java/npng/handdoc/diagnosis/dto/request/SignLogReq.java
+++ b/src/main/java/npng/handdoc/diagnosis/dto/request/SignLogReq.java
@@ -1,0 +1,8 @@
+package npng.handdoc.diagnosis.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SignLogReq(
+        @NotBlank String message
+) {
+}

--- a/src/main/java/npng/handdoc/diagnosis/exception/errorcode/DiagnosisErrorCode.java
+++ b/src/main/java/npng/handdoc/diagnosis/exception/errorcode/DiagnosisErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum DiagnosisErrorCode implements ErrorCode {
     DIAGNOSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 진료가 없습니다."),
+    DIAGNOSIS_ALREADY_ENDED(HttpStatus.CONFLICT, "이미 종료된 진료입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/npng/handdoc/diagnosis/service/DiagnosisService.java
+++ b/src/main/java/npng/handdoc/diagnosis/service/DiagnosisService.java
@@ -1,7 +1,11 @@
 package npng.handdoc.diagnosis.service;
 
 import lombok.RequiredArgsConstructor;
+import npng.handdoc.diagnosis.domain.ChatLog;
 import npng.handdoc.diagnosis.domain.Diagnosis;
+import npng.handdoc.diagnosis.domain.type.MessageType;
+import npng.handdoc.diagnosis.domain.type.Sender;
+import npng.handdoc.diagnosis.dto.request.SignLogReq;
 import npng.handdoc.diagnosis.exception.DiagnosisException;
 import npng.handdoc.diagnosis.exception.errorcode.DiagnosisErrorCode;
 import npng.handdoc.diagnosis.repository.DiagnosisRepository;
@@ -25,9 +29,33 @@ public class DiagnosisService {
 
     // 진료 종료
     public void endDiagnosis(String diagnosisId){
-        Diagnosis diagnosis = diagnosisRepository.findById(diagnosisId).
-                orElseThrow(()-> new DiagnosisException(DiagnosisErrorCode.DIAGNOSIS_NOT_FOUND));
+        Diagnosis diagnosis = findDiagnosisOrThrow(diagnosisId);
         diagnosis.endNow();
         diagnosisRepository.save(diagnosis);
+    }
+
+    // 수어 등록
+    public void saveSignText(String diagnosisId, SignLogReq request){
+        Diagnosis diagnosis = findDiagnosisOrThrow(diagnosisId);
+        validateActive(diagnosis);
+        ChatLog chatLog = ChatLog.builder()
+                .sender(Sender.PATIENT)
+                .messageType(MessageType.MTT)
+                .message(request.message())
+                .build();
+
+        diagnosis.addChatLog(chatLog);
+        diagnosisRepository.save(diagnosis);
+    }
+
+    private Diagnosis findDiagnosisOrThrow(String diagnosisId){
+        return diagnosisRepository.findById(diagnosisId)
+                .orElseThrow(()-> new DiagnosisException(DiagnosisErrorCode.DIAGNOSIS_NOT_FOUND));
+    }
+
+    private void validateActive(Diagnosis diagnosis) {
+        if (!diagnosis.isActive()) {
+            throw new DiagnosisException(DiagnosisErrorCode.DIAGNOSIS_ALREADY_ENDED);
+        }
     }
 }


### PR DESCRIPTION
## 🪺 PR 개요
- `/api/v1/diagnosis/{diagnosisId}/sign` API 구현
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/ea4720dc-63f5-445b-9a96-7b4b2c3bee6c" />

## 🌱 Issue Number
#3

## ✨ 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## 🙏 To Reviewers
> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 진료 내역에 수어로 변환된 텍스트를 저장하는 API 엔드포인트가 추가되었습니다.
* **버그 수정**
  * 진료 종료 상태에 대한 새로운 오류 코드가 추가되어, 이미 종료된 진료에 대한 처리가 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->