### PR TITLE
[FEAT] 요약 API에서 종료되지 않은 진료 세션에 대해 예외 던지기 

### DIFF
--- a/src/main/java/npng/handdoc/diagnosis/exception/errorcode/DiagnosisErrorCode.java
+++ b/src/main/java/npng/handdoc/diagnosis/exception/errorcode/DiagnosisErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum DiagnosisErrorCode implements ErrorCode {
     DIAGNOSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 진료가 없습니다."),
     DIAGNOSIS_ALREADY_ENDED(HttpStatus.CONFLICT, "이미 종료된 진료입니다."),
+    DIAGNOSIS_NOT_ENDED(HttpStatus.BAD_REQUEST, "아직 종료되지 않은 진료입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/npng/handdoc/diagnosis/service/DiagnosisService.java
+++ b/src/main/java/npng/handdoc/diagnosis/service/DiagnosisService.java
@@ -83,6 +83,7 @@ public class DiagnosisService {
     @Transactional
     public SummaryRes getSummary(String diagnosisId){
         Diagnosis diagnosis = findDiagnosisOrThrow(diagnosisId);
+        validateInactive(diagnosis);
         SummaryAIRes summaryAIRes = openAIService.summarize(diagnosis);
         String consultationTime = calculateTime(diagnosis);
         return SummaryRes.of(consultationTime, summaryAIRes.symptom(), summaryAIRes.impression(), summaryAIRes.prescription());
@@ -111,6 +112,12 @@ public class DiagnosisService {
     private void validateActive(Diagnosis diagnosis) {
         if (!diagnosis.isActive()) {
             throw new DiagnosisException(DiagnosisErrorCode.DIAGNOSIS_ALREADY_ENDED);
+        }
+    }
+
+    private void validateInactive(Diagnosis diagnosis) {
+        if (diagnosis.isActive()) {
+            throw new DiagnosisException(DiagnosisErrorCode.DIAGNOSIS_NOT_ENDED);
         }
     }
 }


### PR DESCRIPTION
## 🪺 PR 개요
요약 API 에서 종료되지 않은 진료 세션에 대해서 예외 처리를 설정했습니다. 

## 🌱 Issue Number
- #21

## ✨ 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## 🙏 To Reviewers
>