### PR TITLE
[FEAT] 진료 내역 조회 API 구현

### DIFF
--- a/src/main/java/npng/handdoc/auth/controller/AuthController.java
+++ b/src/main/java/npng/handdoc/auth/controller/AuthController.java
@@ -20,20 +20,20 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
     private final AuthService authService;
 
-    @Operation(summary = "기본 회원가입", description = "(관리자) 이메일과 비밀번호로 회원가입합니다. '@'를 포함한 이메일과 비밀번호를 입력해주세요.")
+    @Operation(summary = "의사 회원가입", description = "(의사) 이메일과 비밀번호로 회원가입합니다. '@'를 포함한 이메일과 비밀번호를 입력해주세요.")
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Object>> signUp(@Valid @RequestBody BasicLoginRequest basicLoginRequest) {
         authService.signup(basicLoginRequest);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
     }
-    @Operation(summary = "기본 로그인", description = "(관리자) 이메일과 비밀번호로 로그인합니다. '@'를 포함한 이메일과 비밀번호를 입력해주세요.")
+    @Operation(summary = "의사 로그인", description = "(의사) 이메일과 비밀번호로 로그인합니다. '@'를 포함한 이메일과 비밀번호를 입력해주세요.")
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<Object>> login(@Valid @RequestBody BasicLoginRequest basicLoginRequest) {
         LoginResponse loginResponse = authService.login(basicLoginRequest);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(loginResponse));
     }
 
-    @Operation(summary = "소셜 로그인 / 회원가입", description = "소셜 로그인을 진행합니다. 인가코드를 넣어주세요.")
+    @Operation(summary = "환자 소셜 로그인 / 회원가입", description = "소셜 로그인을 진행합니다. 인가코드를 넣어주세요.")
     @PostMapping("/login/{loginType}")
     public ResponseEntity<ApiResponse<Object>> login(
             @PathVariable LoginType loginType, @RequestParam String code) {

--- a/src/main/java/npng/handdoc/reservation/domain/Reservation.java
+++ b/src/main/java/npng/handdoc/reservation/domain/Reservation.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import npng.handdoc.global.entity.BaseEntity;
+import npng.handdoc.reservation.domain.type.Option;
 import npng.handdoc.reservation.domain.type.ReservationStatus;
 import npng.handdoc.reservation.domain.type.Symptom;
 import npng.handdoc.user.domain.DoctorProfile;
@@ -11,6 +12,8 @@ import npng.handdoc.user.domain.User;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Getter
 @Entity
@@ -32,6 +35,13 @@ public class Reservation extends BaseEntity {
     @Column(name="status")
     @Enumerated(EnumType.STRING)
     private ReservationStatus status;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "reservation_interpretation",
+            joinColumns = @JoinColumn(name = "reservation_id"))
+    @Column(name="interpretation_option")
+    @Enumerated(EnumType.STRING)
+    private Set<Option> interpretationOption = new HashSet<>();
 
     @Column(name="description")
     private String description;

--- a/src/main/java/npng/handdoc/reservation/domain/Reservation.java
+++ b/src/main/java/npng/handdoc/reservation/domain/Reservation.java
@@ -36,7 +36,7 @@ public class Reservation extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ReservationStatus status;
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "reservation_interpretation",
             joinColumns = @JoinColumn(name = "reservation_id"))
     @Column(name="interpretation_option")

--- a/src/main/java/npng/handdoc/reservation/domain/type/Option.java
+++ b/src/main/java/npng/handdoc/reservation/domain/type/Option.java
@@ -1,0 +1,16 @@
+package npng.handdoc.reservation.domain.type;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Option {
+    SIGN_TO_TEXT("수어 텍스트 변환"),
+    VOICE_TO_TEXT("음성 텍스트 변환");
+
+    private final String label;
+
+    public String getLabel() {
+        return label;
+    }
+    }
+

--- a/src/main/java/npng/handdoc/reservation/repository/ReservationRepository.java
+++ b/src/main/java/npng/handdoc/reservation/repository/ReservationRepository.java
@@ -3,5 +3,8 @@ package npng.handdoc.reservation.repository;
 import npng.handdoc.reservation.domain.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    Optional<Reservation> findByUserId(Long userId);
 }

--- a/src/main/java/npng/handdoc/telemed/controller/TelemedController.java
+++ b/src/main/java/npng/handdoc/telemed/controller/TelemedController.java
@@ -2,7 +2,6 @@ package npng.handdoc.telemed.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import npng.handdoc.diagnosis.dto.response.SummaryRes;
 import npng.handdoc.global.response.ApiResponse;
@@ -10,7 +9,8 @@ import npng.handdoc.telemed.dto.request.SignRequest;
 import npng.handdoc.telemed.service.TelemedChatService;
 import npng.handdoc.telemed.service.TelemedService;
 import npng.handdoc.user.util.CustomUserDetails;
-import org.apache.coyote.Response;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -63,5 +63,14 @@ public class TelemedController {
     public ResponseEntity<SummaryRes> summary(@PathVariable String roomId){
         SummaryRes summary = telemedChatService.saveSummary(roomId);
         return ResponseEntity.ok(summary);
+    }
+
+    @Operation(summary = "비대면 진료 내역 조회 API", description = "비대면 진료 내역을 조회합니다.")
+    @GetMapping("/history")
+    public ResponseEntity<ApiResponse<Object>> history(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                       @RequestParam(defaultValue = "0") int page,
+                                                       @RequestParam(defaultValue = "10") int size){
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(ApiResponse.from(telemedService.getHistory(pageable, userDetails.getId())));
     }
 }

--- a/src/main/java/npng/handdoc/telemed/controller/TelemedController.java
+++ b/src/main/java/npng/handdoc/telemed/controller/TelemedController.java
@@ -61,7 +61,7 @@ public class TelemedController {
     @Operation(summary = "비대면 진료 요약 API", description = "비대면 진료 내용을 요약합니다. roomId를 입력하세요.")
     @GetMapping("/{roomId}/summary")
     public ResponseEntity<SummaryRes> summary(@PathVariable String roomId){
-        SummaryRes summary = telemedChatService.getSummary(roomId);
+        SummaryRes summary = telemedChatService.saveSummary(roomId);
         return ResponseEntity.ok(summary);
     }
 }

--- a/src/main/java/npng/handdoc/telemed/domain/Summary.java
+++ b/src/main/java/npng/handdoc/telemed/domain/Summary.java
@@ -1,6 +1,7 @@
 package npng.handdoc.telemed.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import npng.handdoc.global.entity.BaseEntity;
@@ -15,6 +16,9 @@ public class Summary extends BaseEntity {
     @GeneratedValue(strategy=GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name="consultation_time")
+    private String consultationTime;
+
     @Column(name="symptom")
     private String symptom;
 
@@ -27,4 +31,14 @@ public class Summary extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="telemed_id")
     private Telemed telemed;
+
+    public void setTelemed(Telemed telemed) {this.telemed = telemed;}
+
+    @Builder
+    public Summary(String consultationTime, String symptom, String impression, String prescription) {
+        this.consultationTime = consultationTime;
+        this.symptom = symptom;
+        this.impression = impression;
+        this.prescription = prescription;
+    }
 }

--- a/src/main/java/npng/handdoc/telemed/domain/Summary.java
+++ b/src/main/java/npng/handdoc/telemed/domain/Summary.java
@@ -1,4 +1,30 @@
 package npng.handdoc.telemed.domain;
 
-public class Summary {
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import npng.handdoc.global.entity.BaseEntity;
+
+@Getter
+@Entity
+@Table(name="summary")
+@RequiredArgsConstructor
+public class Summary extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy=GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="symptom")
+    private String symptom;
+
+    @Column(name="impression")
+    private String impression;
+
+    @Column(name="prescription")
+    private String prescription;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="telemed_id")
+    private Telemed telemed;
 }

--- a/src/main/java/npng/handdoc/telemed/domain/Summary.java
+++ b/src/main/java/npng/handdoc/telemed/domain/Summary.java
@@ -1,0 +1,4 @@
+package npng.handdoc.telemed.domain;
+
+public class Summary {
+}

--- a/src/main/java/npng/handdoc/telemed/domain/Telemed.java
+++ b/src/main/java/npng/handdoc/telemed/domain/Telemed.java
@@ -73,4 +73,9 @@ public class Telemed extends BaseEntity {
         this.diagnosisStatus = DiagnosisStatus.ENDED;
         this.endedAt = LocalDateTime.now();
     }
+
+    public void addSummary(Summary summary) {
+        this.summary = summary;
+        summary.setTelemed(this);
+    }
 }

--- a/src/main/java/npng/handdoc/telemed/domain/Telemed.java
+++ b/src/main/java/npng/handdoc/telemed/domain/Telemed.java
@@ -24,6 +24,9 @@ public class Telemed extends BaseEntity {
     @JoinColumn(name="reservation_id")
     private Reservation reservation;
 
+    @OneToOne(mappedBy = "telemed", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Summary summary;
+
     @Column(name="status")
     @Enumerated(EnumType.STRING)
     private DiagnosisStatus diagnosisStatus; // WAITING, ACTIVE, ENDED

--- a/src/main/java/npng/handdoc/telemed/dto/response/HistoryItemResponse.java
+++ b/src/main/java/npng/handdoc/telemed/dto/response/HistoryItemResponse.java
@@ -1,0 +1,27 @@
+package npng.handdoc.telemed.dto.response;
+
+import npng.handdoc.reservation.domain.Reservation;
+import npng.handdoc.telemed.domain.Telemed;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record HistoryItemResponse(
+        LocalDate slotDate,
+        LocalTime startTime,
+        LocalTime endTime,
+        String doctorName,
+        String hospitalName,
+        String symptom
+) {
+
+    public static HistoryItemResponse from(Reservation reservation, Telemed telemed) {
+        return new HistoryItemResponse(
+                reservation.getSlotDate(),
+                reservation.getStartTime(),
+                reservation.getEndTime(),
+                reservation.getDoctorProfile().getUser().getName(),
+                reservation.getDoctorProfile().getHospitalName(),
+                telemed.getSummary().getSymptom());
+    }
+}

--- a/src/main/java/npng/handdoc/telemed/dto/response/HistoryListResponse.java
+++ b/src/main/java/npng/handdoc/telemed/dto/response/HistoryListResponse.java
@@ -1,0 +1,25 @@
+package npng.handdoc.telemed.dto.response;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record HistoryListResponse(
+        List<HistoryItemResponse> items,
+        long totalElements,
+        int totalPages,
+        int page,
+        int size,
+        boolean hasNext
+) {
+    public static HistoryListResponse from(Page<HistoryItemResponse> page){
+        return new HistoryListResponse(
+                page.getContent(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getNumber(),
+                page.getSize(),
+                page.hasNext()
+        );
+    }
+}

--- a/src/main/java/npng/handdoc/telemed/dto/response/JoinResponse.java
+++ b/src/main/java/npng/handdoc/telemed/dto/response/JoinResponse.java
@@ -1,5 +1,7 @@
 package npng.handdoc.telemed.dto.response;
 
+import npng.handdoc.reservation.domain.Reservation;
+import npng.handdoc.reservation.domain.type.Option;
 import npng.handdoc.telemed.domain.Telemed;
 import npng.handdoc.telemed.domain.type.DiagnosisStatus;
 import npng.handdoc.user.domain.type.Role;
@@ -11,17 +13,19 @@ public record JoinResponse(
         Role role,
         DiagnosisStatus status,
         String wsUrl,
-        List<IceServer> iceServers) {
+        List<IceServer> iceServers,
+        List<Option> interpretationOption) {
 
     public static record IceServer(String urls){}
 
-    public static JoinResponse from(Telemed telemed, Role role, String wsUrl, List<IceServer> iceServers) {
+    public static JoinResponse from(Telemed telemed, Role role, String wsUrl, List<IceServer> iceServers, Reservation reservation) {
         return new JoinResponse(
                 telemed.getId(),
                 role,
                 telemed.getDiagnosisStatus(),
                 wsUrl,
-                iceServers
+                iceServers,
+                reservation.getInterpretationOption().stream().toList()
         );
     }
 }

--- a/src/main/java/npng/handdoc/telemed/repository/SummaryRepository.java
+++ b/src/main/java/npng/handdoc/telemed/repository/SummaryRepository.java
@@ -1,0 +1,7 @@
+package npng.handdoc.telemed.repository;
+
+import npng.handdoc.telemed.domain.Summary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SummaryRepository extends JpaRepository<Summary, Long> {
+}

--- a/src/main/java/npng/handdoc/telemed/repository/TelemedRepository.java
+++ b/src/main/java/npng/handdoc/telemed/repository/TelemedRepository.java
@@ -1,6 +1,10 @@
 package npng.handdoc.telemed.repository;
 
 import npng.handdoc.telemed.domain.Telemed;
+import npng.handdoc.telemed.domain.type.DiagnosisStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +12,17 @@ import java.util.Optional;
 public interface TelemedRepository extends JpaRepository<Telemed, String> {
     Optional<Telemed> findByReservationId(Long reservationId);
     Optional<Telemed> findById(String roomId);
+    Optional<Telemed> findByPatientId(Long userId);
+
+    @EntityGraph(attributePaths = {
+            "reservation",
+            "reservation.doctorProfile",
+            "reservation.doctorProfile.user",
+            "summary"
+    })
+    Page<Telemed> findByPatientIdAndDiagnosisStatusOrderByStartedAtDesc(
+            Long patientId,
+            DiagnosisStatus status,
+            Pageable pageable
+    );
 }

--- a/src/main/java/npng/handdoc/telemed/service/TelemedService.java
+++ b/src/main/java/npng/handdoc/telemed/service/TelemedService.java
@@ -53,7 +53,7 @@ public class TelemedService {
         // 둘 다 입장하면 ACTIVE 전환
         telemed.activateIfBothJoined();
         telemedRepository.save(telemed);
-        return JoinResponse.from(telemed, role, WS_URL, DEFAULT_ICE);
+        return JoinResponse.from(telemed, role, WS_URL, DEFAULT_ICE, reservation);
     }
 
     @Transactional

--- a/src/main/java/npng/handdoc/user/domain/User.java
+++ b/src/main/java/npng/handdoc/user/domain/User.java
@@ -51,7 +51,7 @@ public class User extends BaseEntity {
     }
 
     public void addResidentId(String residentId){
-        this.name = name;
+        this.residentId = residentId;
     }
 
     @Builder(builderMethodName = "basicLoginBuilder", buildMethodName = "buildBasicLogin")


### PR DESCRIPTION
## 🪺 PR 개요
진료 내역 조회 API를 구현했습니다. 
통역 옵션을 Reservation 엔티티에 추가 


## 🌱 Issue Number
- #52
## ✨ 변경 사항
- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## 🙏 To Reviewers
>
