### PR TITLE
feat: 진료 예약(Reservation) 관련 API 5개 구현 (#41)

### DIFF
--- a/src/main/java/npng/handdoc/reservation/controller/ReservationController.java
+++ b/src/main/java/npng/handdoc/reservation/controller/ReservationController.java
@@ -1,11 +1,76 @@
 package npng.handdoc.reservation.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import npng.handdoc.global.response.ApiResponse;
+import npng.handdoc.reservation.dto.request.ReservationAcceptRequest;
+import npng.handdoc.reservation.dto.request.ReservationCreateRequest;
+import npng.handdoc.reservation.service.ReservationService;
+import npng.handdoc.user.util.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/reservation")
+@Tag(name = "Reservation", description = "진료 예약 API")
 public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @Operation(summary = "환자 진료 예약 생성")
+    @PostMapping
+    public ResponseEntity<ApiResponse<Object>> createReservation(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @Valid @RequestBody ReservationCreateRequest request
+    ) {
+        Long patientUserId   = principal.getId();
+        Long doctorProfileId = request.doctorProfileId();
+        var dto = reservationService.create(patientUserId, doctorProfileId, request);
+        return ResponseEntity.ok(ApiResponse.from(dto));
+    }
+
+    @Operation(summary = "환자 진료 예약 취소")
+    @DeleteMapping("/{reservationId}")
+    public ResponseEntity<ApiResponse<Object>> cancelReservation(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long reservationId
+    ) {
+        reservationService.cancel(reservationId, principal.getId());
+        return ResponseEntity.ok(ApiResponse.EMPTY_RESPONSE);
+    }
+
+    @Operation(summary = "의사 진료 예약 전체 조회")
+    @GetMapping
+    public ResponseEntity<ApiResponse<Object>> listForDoctor(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @RequestParam(defaultValue = "10") @Min(1) int size,
+            @RequestParam(defaultValue = "0")  @Min(0) int page
+    ) {
+        Long doctorUserId = principal.getId(); // ★ userId만 전달
+        var dto = reservationService.listForDoctor(doctorUserId, size, page);
+        return ResponseEntity.ok(ApiResponse.from(dto));
+    }
+
+    @Operation(summary = "진료 예약 단건 상세 조회")
+    @GetMapping("/{reservationId}")
+    public ResponseEntity<ApiResponse<Object>> getOne(@PathVariable Long reservationId) {
+        return ResponseEntity.ok(ApiResponse.from(reservationService.getOne(reservationId)));
+    }
+
+    @Operation(summary = "의사 예약 수락/거부")
+    @PostMapping("/{reservationId}/accept")
+    public ResponseEntity<ApiResponse<Object>> acceptOrDeny(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long reservationId,
+            @Valid @RequestBody ReservationAcceptRequest request
+    ) {
+        Long doctorUserId = principal.getId(); // ★ userId만 전달
+        var dto = reservationService.acceptOrDeny(reservationId, doctorUserId, request);
+        return ResponseEntity.ok(ApiResponse.from(dto));
+    }
 }

--- a/src/main/java/npng/handdoc/reservation/domain/Reservation.java
+++ b/src/main/java/npng/handdoc/reservation/domain/Reservation.java
@@ -3,6 +3,7 @@ package npng.handdoc.reservation.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import npng.handdoc.global.entity.BaseEntity;
 import npng.handdoc.reservation.domain.type.Option;
 import npng.handdoc.reservation.domain.type.ReservationStatus;
@@ -16,24 +17,23 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Getter
+@Setter
 @Entity
 @Table(name="reservation")
 @RequiredArgsConstructor
 public class Reservation extends BaseEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name="symptom")
     @Enumerated(EnumType.STRING)
+    @Column(name="symptom")
     private Symptom symptom;
 
     @Column(name="symptom_duration")
     private Long symptomDuration;
 
-    @Column(name="status")
     @Enumerated(EnumType.STRING)
+    @Column(name="status")
     private ReservationStatus status;
 
     @ElementCollection(fetch = FetchType.LAZY)
@@ -55,11 +55,9 @@ public class Reservation extends BaseEntity {
     @Column(name="end_time")
     private LocalTime endTime;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="user_id")
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name="user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="doctor_profile_id")
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name="doctor_profile_id")
     private DoctorProfile doctorProfile;
 }

--- a/src/main/java/npng/handdoc/reservation/domain/type/ReservationStatus.java
+++ b/src/main/java/npng/handdoc/reservation/domain/type/ReservationStatus.java
@@ -4,12 +4,11 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum ReservationStatus {
-    PENDING("예약 확인 중"),
-    CONFIRMED("예약 완료");
+    REQUESTED("예약 확인 중"),   // 추가
+    CONFIRMED("예약 완료"),
+    CANCELED("예약 취소"),      // 추가
+    COMPLETED("진료 완료");     // 추가
 
     private final String label;
-
-    public String getLabel() {
-        return label;
-    }
+    public String getLabel() { return label; }
 }

--- a/src/main/java/npng/handdoc/reservation/dto/request/ReservationAcceptRequest.java
+++ b/src/main/java/npng/handdoc/reservation/dto/request/ReservationAcceptRequest.java
@@ -1,0 +1,12 @@
+package npng.handdoc.reservation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "의사 예약 수락/거부 요청")
+public record ReservationAcceptRequest(
+        @NotNull @Schema(description = "수락 여부", example = "true")
+        Boolean accept,
+        @Schema(description = "거부 사유(거부 시 선택/입력)", example = "야간 진료 불가")
+        String reason
+) {}

--- a/src/main/java/npng/handdoc/reservation/dto/request/ReservationCreateRequest.java
+++ b/src/main/java/npng/handdoc/reservation/dto/request/ReservationCreateRequest.java
@@ -1,0 +1,25 @@
+package npng.handdoc.reservation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Schema(description = "환자 진료 예약 생성 요청")
+public record ReservationCreateRequest(
+        @NotNull @Schema(description = "의사 프로필 ID", example = "101")
+        Long doctorProfileId,
+        @NotNull @Schema(description = "예약 날짜", example = "2025-09-20")
+        LocalDate slotDate,
+        @NotNull @Schema(description = "시작 시간", example = "14:00:00")
+        LocalTime startTime,
+        @NotNull @Schema(description = "종료 시간", example = "14:30:00")
+        LocalTime endTime,
+        @Schema(description = "증상(enum 문자열, 미선택 시 null)", example = "HEADACHE")
+        String symptom,
+        @Schema(description = "증상 지속 시간(분), 미선택 가능", example = "30")
+        Long symptomDuration,
+        @Schema(description = "기타 증상", example = "머리가 어지러워요")
+        String description
+) {}

--- a/src/main/java/npng/handdoc/reservation/dto/response/ReservationListResponse.java
+++ b/src/main/java/npng/handdoc/reservation/dto/response/ReservationListResponse.java
@@ -1,0 +1,20 @@
+package npng.handdoc.reservation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "예약 목록 응답")
+public record ReservationListResponse(
+        List<ReservationResponse> items,
+        PageMeta page
+) {
+    @Schema(description = "페이지 정보")
+    public record PageMeta(
+            int size,
+            int page,
+            boolean hasNext,
+            long totalElements,
+            int totalPages
+    ) {}
+}

--- a/src/main/java/npng/handdoc/reservation/dto/response/ReservationResponse.java
+++ b/src/main/java/npng/handdoc/reservation/dto/response/ReservationResponse.java
@@ -1,0 +1,23 @@
+package npng.handdoc.reservation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Schema(description = "예약 단건 응답")
+public record ReservationResponse(
+        Long id,
+        Long patientId,
+        Long doctorProfileId,
+        String status,
+        String symptom,
+        Long symptomDuration,
+        String description,
+        LocalDate slotDate,
+        LocalTime startTime,
+        LocalTime endTime,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {}

--- a/src/main/java/npng/handdoc/reservation/exception/errorcode/ReservationErrorCode.java
+++ b/src/main/java/npng/handdoc/reservation/exception/errorcode/ReservationErrorCode.java
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ReservationErrorCode implements ErrorCode {
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약이 존재하지 않습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "시작/종료 시간이 올바르지 않습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/npng/handdoc/reservation/repository/ReservationRepository.java
+++ b/src/main/java/npng/handdoc/reservation/repository/ReservationRepository.java
@@ -1,10 +1,38 @@
 package npng.handdoc.reservation.repository;
 
 import npng.handdoc.reservation.domain.Reservation;
+import npng.handdoc.reservation.domain.type.ReservationStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
-    Optional<Reservation> findByUserId(Long userId);
+    Page<Reservation> findAllByDoctorProfile_Id(Long doctorProfileId, Pageable pageable);
+    Page<Reservation> findAllByUser_Id(Long userId, Pageable pageable);
+    long countByDoctorProfile_IdAndStatus(Long doctorProfileId, ReservationStatus status);
+
+    // 의사 유저ID 기준 조회/검증
+    Page<Reservation> findAllByDoctorProfile_User_Id(Long doctorUserId, Pageable pageable);
+    Optional<Reservation> findByIdAndDoctorProfile_User_Id(Long reservationId, Long doctorUserId);
+
+
+    boolean existsByDoctorProfile_IdAndSlotDateAndStartTimeLessThanAndEndTimeGreaterThan(
+            Long doctorProfileId,
+            java.time.LocalDate slotDate,
+            java.time.LocalTime endTimeExclusive,
+            java.time.LocalTime startTimeExclusive
+    );
+
+    @Query(value = """
+        select * 
+          from reservation 
+         where user_id = :userId 
+         order by id desc 
+         limit 1
+        """, nativeQuery = true)
+    Optional<Reservation> findByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/npng/handdoc/reservation/service/ReservationService.java
+++ b/src/main/java/npng/handdoc/reservation/service/ReservationService.java
@@ -1,9 +1,140 @@
 package npng.handdoc.reservation.service;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
+import npng.handdoc.reservation.domain.Reservation;
+import npng.handdoc.reservation.domain.type.ReservationStatus;
+import npng.handdoc.reservation.domain.type.Symptom;
+import npng.handdoc.reservation.dto.request.ReservationAcceptRequest;
+import npng.handdoc.reservation.dto.request.ReservationCreateRequest;
+import npng.handdoc.reservation.dto.response.ReservationListResponse;
+import npng.handdoc.reservation.dto.response.ReservationResponse;
+import npng.handdoc.reservation.exception.ReservationException;
+import npng.handdoc.reservation.exception.errorcode.ReservationErrorCode;
+import npng.handdoc.reservation.repository.ReservationRepository;
+import npng.handdoc.user.domain.DoctorProfile;
+import npng.handdoc.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    private ReservationResponse toResponse(Reservation e) {
+        return new ReservationResponse(
+                e.getId(),
+                e.getUser() != null ? e.getUser().getId() : null,
+                e.getDoctorProfile() != null ? e.getDoctorProfile().getId() : null,
+                e.getStatus() != null ? e.getStatus().name() : null,
+                e.getSymptom() != null ? e.getSymptom().name() : null,
+                e.getSymptomDuration(),
+                e.getDescription(),
+                e.getSlotDate(),
+                e.getStartTime(),
+                e.getEndTime(),
+                null,
+                null
+        );
+    }
+
+    private ReservationListResponse toListResponse(Page<Reservation> page) {
+        var items = page.getContent().stream().map(this::toResponse).toList();
+        var meta = new ReservationListResponse.PageMeta(
+                page.getSize(),
+                page.getNumber(),
+                page.hasNext(),
+                page.getTotalElements(),
+                page.getTotalPages()
+        );
+        return new ReservationListResponse(items, meta);
+    }
+
+
+    // 환자 예약 생성
+    @Transactional
+    public ReservationResponse create(Long patientUserId, Long doctorProfileId, ReservationCreateRequest req) {
+
+        if (!req.startTime().isBefore(req.endTime())) {
+            throw new ReservationException(ReservationErrorCode.INVALID_TIME_RANGE);
+        }
+
+        User patient = em.getReference(User.class, patientUserId);
+        DoctorProfile doctor = em.getReference(DoctorProfile.class, doctorProfileId);
+
+        var entity = new Reservation();
+        entity.setUser(patient);
+        entity.setDoctorProfile(doctor);
+        entity.setStatus(ReservationStatus.REQUESTED);
+
+        if (req.symptom() != null && !req.symptom().isBlank()) {
+            try {
+                entity.setSymptom(Symptom.valueOf(req.symptom()));
+            } catch (IllegalArgumentException ex) {
+                throw new ReservationException(ReservationErrorCode.ACCESS_DENIED);
+            }
+        }
+        entity.setSymptomDuration(req.symptomDuration());
+        entity.setDescription(req.description());
+        entity.setSlotDate(req.slotDate());
+        entity.setStartTime(req.startTime());
+        entity.setEndTime(req.endTime());
+
+        var saved = reservationRepository.save(entity);
+        return toResponse(saved);
+    }
+
+    // 환자 예약 취소
+    @Transactional
+    public void cancel(Long reservationId, Long requesterUserId) {
+        var e = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+        if (!e.getUser().getId().equals(requesterUserId)) {
+            throw new ReservationException(ReservationErrorCode.ACCESS_DENIED);
+        }
+        if (e.getStatus() == ReservationStatus.CANCELED || e.getStatus() == ReservationStatus.COMPLETED) {
+            return;
+        }
+        e.setStatus(ReservationStatus.CANCELED);
+    }
+
+    // 의사 예약 전체 조회 — 의사 "유저ID"로 바로 검색
+    @Transactional(readOnly = true)
+    public ReservationListResponse listForDoctor(Long doctorUserId, int size, int page) {
+        var pageable = PageRequest.of(page, size,
+                Sort.by(Sort.Direction.DESC, "slotDate").and(Sort.by("startTime")));
+        var p = reservationRepository.findAllByDoctorProfile_User_Id(doctorUserId, pageable);
+        return toListResponse(p);
+    }
+
+    // (공통) 단건 상세
+    @Transactional(readOnly = true)
+    public ReservationResponse getOne(Long reservationId) {
+        var e = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+        return toResponse(e);
+    }
+
+    // 의사 수락/거부 — 의사 유저ID로 소유권 검증
+    @Transactional
+    public ReservationResponse acceptOrDeny(Long reservationId, Long doctorUserId, ReservationAcceptRequest req) {
+        var e = reservationRepository.findByIdAndDoctorProfile_User_Id(reservationId, doctorUserId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.ACCESS_DENIED));
+
+        e.setStatus(Boolean.TRUE.equals(req.accept())
+                ? ReservationStatus.CONFIRMED
+                : ReservationStatus.CANCELED);
+
+        return toResponse(e);
+    }
 }


### PR DESCRIPTION
## 🪺 PR 개요
- 환자 진료 예약 생성 (POST /api/v2/reservation)
- 의사 진료 예약 전체 조회 (GET /api/v2/reservation)
- 진료 예약 단건 상세 조회 (GET /api/v2/reservation/{reservationId})
- 환자 진료 예약 취소 (DELETE /api/v2/reservation/{reservationId})
- 의사 예약 수락/거부 (POST /api/v2/reservation/{reservationId}/accept)

## 🌱 Issue Number
- #41 

## ✨ 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## 🙏 To Reviewers
