### PR TITLE
[FEAT] 진료 내역 상세 조회 API 구현 및 진료 내역 조회 수정

### DIFF
--- a/src/main/java/npng/handdoc/reservation/service/ReservationService.java
+++ b/src/main/java/npng/handdoc/reservation/service/ReservationService.java
@@ -88,10 +88,8 @@ public class ReservationService {
 
     // 의사 예약 리스트 조회
     @Transactional(readOnly = true)
-    public ReservationListResponse getReservationList(Long doctorUserId, Pageable pageable) {
-        DoctorProfile doctorProfile = doctorProfileRepository.findByUserId(doctorUserId) // ← 언더스코어 제거
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
-
+    public ReservationListResponse getReservationList(Long userId, Pageable pageable) {
+        DoctorProfile doctorProfile = getDoctorOrThrowByUserId(userId);
         Page<Reservation> reservationPage =
                 reservationRepository.findByDoctorProfile_Id(doctorProfile.getId(), pageable);
         Page<ReservationItemResponse> reservationResponsePage = reservationPage.map(ReservationItemResponse::from);
@@ -121,6 +119,10 @@ public class ReservationService {
 
     private DoctorProfile getDoctorOrThrow(Long doctorProfileId) {
         return doctorProfileRepository.findById(doctorProfileId).orElseThrow(()-> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    private DoctorProfile getDoctorOrThrowByUserId(Long userId){
+        return doctorProfileRepository.findByUserId(userId).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
     }
 
     private boolean hasRole(CustomUserDetails principal, String role) {

--- a/src/main/java/npng/handdoc/telemed/controller/TelemedController.java
+++ b/src/main/java/npng/handdoc/telemed/controller/TelemedController.java
@@ -58,7 +58,7 @@ public class TelemedController {
         return ResponseEntity.ok(ApiResponse.from(result));
     }
 
-    @Operation(summary = "비대면 진료 요약 API", description = "비대면 진료 내용을 요약합니다. roomId를 입력하세요.")
+    @Operation(summary = "비대면 진료 요약 API", description = "비대면 진료가 종료된 다음 해당 진료의 내용을 요약합니다. roomId를 입력하세요.")
     @GetMapping("/{roomId}/summary")
     public ResponseEntity<SummaryResponse> summary(@PathVariable String roomId){
         SummaryResponse summary = telemedChatService.saveSummary(roomId);
@@ -72,5 +72,11 @@ public class TelemedController {
                                                        @RequestParam(defaultValue = "10") int size){
         Pageable pageable = PageRequest.of(page, size);
         return ResponseEntity.ok(ApiResponse.from(telemedService.getHistory(pageable, userDetails.getId())));
+    }
+
+    @Operation(summary = "비대면 진료 내역 상세 조회 API", description = "비대면 진료에서 의사와 환자의 대화 내용과 요약을 조회합니다.")
+    @GetMapping("/history/{roomId}")
+    public ResponseEntity<ApiResponse<Object>> historyDetail(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable String roomId){
+        return ResponseEntity.ok(ApiResponse.from(telemedService.getHistoryDetail(userDetails.getId(), roomId)));
     }
 }

--- a/src/main/java/npng/handdoc/telemed/controller/TelemedController.java
+++ b/src/main/java/npng/handdoc/telemed/controller/TelemedController.java
@@ -50,7 +50,7 @@ public class TelemedController {
     }
 
     @Operation(summary = "(의사) 텍스트로 변환된 음성을 db에 저장하는 API", description = "의사의 음성 텍스트를 db에 저장합니다.")
-    @PostMapping(value = "/{roomId}/speech", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/{roomId}/speech-doctor", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Object>> speech(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                       @PathVariable String roomId,
                                                       @RequestPart("file") MultipartFile file)throws Exception{

--- a/src/main/java/npng/handdoc/telemed/dto/response/ChatListResponse.java
+++ b/src/main/java/npng/handdoc/telemed/dto/response/ChatListResponse.java
@@ -1,0 +1,7 @@
+package npng.handdoc.telemed.dto.response;
+
+import java.util.List;
+
+public record ChatListResponse(
+        String roomId,
+        List<ChatResponse> messages) {}

--- a/src/main/java/npng/handdoc/telemed/dto/response/ChatResponse.java
+++ b/src/main/java/npng/handdoc/telemed/dto/response/ChatResponse.java
@@ -1,0 +1,8 @@
+package npng.handdoc.telemed.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ChatResponse(
+        String sender,
+        String message,
+        LocalDateTime timestamp) {}

--- a/src/main/java/npng/handdoc/telemed/dto/response/ChatResponse.java
+++ b/src/main/java/npng/handdoc/telemed/dto/response/ChatResponse.java
@@ -1,8 +1,10 @@
 package npng.handdoc.telemed.dto.response;
 
+import npng.handdoc.telemed.domain.type.Sender;
+
 import java.time.LocalDateTime;
 
 public record ChatResponse(
-        String sender,
+        Sender sender,
         String message,
         LocalDateTime timestamp) {}

--- a/src/main/java/npng/handdoc/telemed/dto/response/HistoryDetailResponse.java
+++ b/src/main/java/npng/handdoc/telemed/dto/response/HistoryDetailResponse.java
@@ -12,7 +12,7 @@ public record HistoryDetailResponse(
                 chatLog.getRoomId(),
                 chatLog.getMessageList().stream()
                         .map(m -> new ChatResponse(
-                                m.getSender().getLabel(),
+                                m.getSender(),
                                 m.getMessage(),
                                 m.getTimestamp()
                         )).toList()

--- a/src/main/java/npng/handdoc/telemed/dto/response/HistoryDetailResponse.java
+++ b/src/main/java/npng/handdoc/telemed/dto/response/HistoryDetailResponse.java
@@ -1,0 +1,24 @@
+package npng.handdoc.telemed.dto.response;
+
+import npng.handdoc.telemed.domain.Summary;
+import npng.handdoc.telemed.domain.TelemedChatLog;
+
+public record HistoryDetailResponse(
+        ChatListResponse chat,
+        SummaryResponse summary
+) {
+    public static HistoryDetailResponse from(TelemedChatLog chatLog, Summary summary) {
+        ChatListResponse chatListResponse = new ChatListResponse(
+                chatLog.getRoomId(),
+                chatLog.getMessageList().stream()
+                        .map(m -> new ChatResponse(
+                                m.getSender().getLabel(),
+                                m.getMessage(),
+                                m.getTimestamp()
+                        )).toList()
+        );
+
+        SummaryResponse summaryResponse = SummaryResponse.from(summary);
+        return new HistoryDetailResponse(chatListResponse, summaryResponse);
+    }
+}

--- a/src/main/java/npng/handdoc/telemed/dto/response/HistoryItemResponse.java
+++ b/src/main/java/npng/handdoc/telemed/dto/response/HistoryItemResponse.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 public record HistoryItemResponse(
+        String roomId,
         LocalDate slotDate,
         LocalTime startTime,
         LocalTime endTime,
@@ -17,6 +18,7 @@ public record HistoryItemResponse(
 
     public static HistoryItemResponse from(Reservation reservation, Telemed telemed) {
         return new HistoryItemResponse(
+                telemed.getId(),
                 reservation.getSlotDate(),
                 reservation.getStartTime(),
                 reservation.getEndTime(),

--- a/src/main/java/npng/handdoc/telemed/dto/response/HistoryItemResponse.java
+++ b/src/main/java/npng/handdoc/telemed/dto/response/HistoryItemResponse.java
@@ -22,6 +22,6 @@ public record HistoryItemResponse(
                 reservation.getEndTime(),
                 reservation.getDoctorProfile().getUser().getName(),
                 reservation.getDoctorProfile().getHospitalName(),
-                telemed.getSummary().getSymptom());
+                reservation.getSymptom().getLabel());
     }
 }

--- a/src/main/java/npng/handdoc/telemed/dto/response/SummaryResponse.java
+++ b/src/main/java/npng/handdoc/telemed/dto/response/SummaryResponse.java
@@ -1,0 +1,19 @@
+package npng.handdoc.telemed.dto.response;
+
+import npng.handdoc.telemed.domain.Summary;
+
+public record SummaryResponse(
+        String consultationTime,
+        String symptom,
+        String impression,
+        String prescription
+) {
+    public static SummaryResponse from(Summary summary) {
+        return new SummaryResponse(
+                summary.getConsultationTime(),
+                summary.getSymptom(),
+                summary.getImpression(),
+                summary.getPrescription()
+        );
+    }
+}

--- a/src/main/java/npng/handdoc/telemed/exception/errorcode/TelemedErrorCode.java
+++ b/src/main/java/npng/handdoc/telemed/exception/errorcode/TelemedErrorCode.java
@@ -11,7 +11,8 @@ public enum TelemedErrorCode implements ErrorCode {
     NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "이 예약의 환자/의사만 입장할 수 있습니다."),
     RESERVATION_NOT_CONFIRMED(HttpStatus.CONFLICT, "예약이 확정 상태가 아닙니다."),
     ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 방이 존재하지 않습니다."),
-    ALREADY_ROOM_ENDED(HttpStatus.NOT_FOUND, "이미 종료된 방입니다.")
+    ALREADY_ROOM_ENDED(HttpStatus.NOT_FOUND, "이미 종료된 방입니다."),
+    SUMMARY_NOT_FOUND(HttpStatus.NOT_FOUND, "진료 요약이 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/npng/handdoc/telemed/repository/SummaryRepository.java
+++ b/src/main/java/npng/handdoc/telemed/repository/SummaryRepository.java
@@ -3,5 +3,8 @@ package npng.handdoc.telemed.repository;
 import npng.handdoc.telemed.domain.Summary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SummaryRepository extends JpaRepository<Summary, Long> {
+    Optional<Summary> findByTelemed_Id(String telemedId);
 }


### PR DESCRIPTION
## 🪺 PR 개요
- 진료 내역 상세 조회 API 구현 
- 진료 내역 조회 시에 증상 부분을 예약에서 가져오도록 수정 
- 자잘한 수정 (API 엔드포인트 수정, 의사 예약 리스트 조회 시에 예외 던지는 부분을 private 메서드로 분리) 

## 🌱 Issue Number
- #73

## ✨ 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## 🙏 To Reviewers
>
