### PR TITLE
[BUG] 진료 요약 api 2번 호출 시 500에러 발생

### DIFF
--- a/src/main/java/npng/handdoc/telemed/controller/TelemedController.java
+++ b/src/main/java/npng/handdoc/telemed/controller/TelemedController.java
@@ -85,7 +85,7 @@ public class TelemedController {
         return ResponseEntity.ok(ApiResponse.EMPTY_RESPONSE);
     }
 
-    @Operation(summary = "비대면 진료 요약 API", description = "비대면 진료가 종료된 다음 해당 진료의 내용을 요약합니다. roomId를 입력하세요.")
+    @Operation(summary = "비대면 진료 요약 조회 API", description = "비대면 진료가 종료된 다음 해당 진료 요약을 조회합니다. roomId를 입력하세요.")
     @GetMapping("/{roomId}/summary")
     public ResponseEntity<SummaryResponse> summary(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                    @PathVariable String roomId){

--- a/src/main/java/npng/handdoc/telemed/controller/TelemedController.java
+++ b/src/main/java/npng/handdoc/telemed/controller/TelemedController.java
@@ -34,7 +34,7 @@ public class TelemedController {
         return ResponseEntity.ok(ApiResponse.from(telemedService.join(userDetails.getId(), reservationId)));
     }
 
-    @Operation(summary = "(환자, 의사) 진료실 종료 API", description = "진료 종료 버튼을 통해 화상 통화를 마무리합니다. roomId를 입력해주세요.")
+    @Operation(summary = "(환자, 의사) 진료실 종료 API", description = "진료 종료 버튼을 통해 화상 통화를 마무리하고 요약을 생성하여 db에 넣습니다. roomId를 입력해주세요.")
     @PostMapping("/{roomId}/end")
     public ResponseEntity<ApiResponse<Object>> end(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                    @PathVariable String roomId) {

--- a/src/main/java/npng/handdoc/telemed/controller/TelemedController.java
+++ b/src/main/java/npng/handdoc/telemed/controller/TelemedController.java
@@ -87,8 +87,9 @@ public class TelemedController {
 
     @Operation(summary = "비대면 진료 요약 API", description = "비대면 진료가 종료된 다음 해당 진료의 내용을 요약합니다. roomId를 입력하세요.")
     @GetMapping("/{roomId}/summary")
-    public ResponseEntity<SummaryResponse> summary(@PathVariable String roomId){
-        SummaryResponse summary = telemedChatService.saveSummary(roomId);
+    public ResponseEntity<SummaryResponse> summary(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                   @PathVariable String roomId){
+        SummaryResponse summary = telemedChatService.getSummary(userDetails.getId(), roomId);
         return ResponseEntity.ok(summary);
     }
 

--- a/src/main/java/npng/handdoc/telemed/service/TelemedService.java
+++ b/src/main/java/npng/handdoc/telemed/service/TelemedService.java
@@ -39,6 +39,7 @@ public class TelemedService {
     private final TelemedChatRepository telemedChatRepository;
     private final SummaryRepository summaryRepository;
 
+    @Transactional
     public JoinResponse join(Long userId, Long reservationId){
         Reservation reservation = findReservationOrElse(reservationId);
         if(reservation.getStatus() != ReservationStatus.CONFIRMED){
@@ -58,7 +59,6 @@ public class TelemedService {
 
         // 둘 다 입장하면 ACTIVE 전환
         telemed.activateIfBothJoined();
-        telemedRepository.save(telemed);
         return JoinResponse.from(telemed, role, WS_URL, DEFAULT_ICE, reservation);
     }
 

--- a/src/main/java/npng/handdoc/telemed/service/TelemedService.java
+++ b/src/main/java/npng/handdoc/telemed/service/TelemedService.java
@@ -101,7 +101,7 @@ public class TelemedService {
         if (!telemed.getPatientId().equals(userId)) {
             throw new TelemedException(NOT_PARTICIPANT);
         }
-        TelemedChatLog chatLog = findTelmedChatLogOrElse(roomId);
+        TelemedChatLog chatLog = findTelemedChatLogOrElse(roomId);
         Summary summary = findSummaryOrElse(roomId);
         return HistoryDetailResponse.from(chatLog, summary);
     }
@@ -153,7 +153,7 @@ public class TelemedService {
         return telemedRepository.findById(roomId).orElseThrow(()-> new TelemedException(ROOM_NOT_FOUND));
     }
 
-    private TelemedChatLog findTelmedChatLogOrElse(String roomId) {
+    private TelemedChatLog findTelemedChatLogOrElse(String roomId) {
         return telemedChatRepository.findByRoomId(roomId).orElseThrow(()-> new TelemedException(ROOM_NOT_FOUND));
 
     }

--- a/src/main/java/npng/handdoc/telemed/service/TelemedService.java
+++ b/src/main/java/npng/handdoc/telemed/service/TelemedService.java
@@ -155,7 +155,6 @@ public class TelemedService {
 
     private TelemedChatLog findTelemedChatLogOrElse(String roomId) {
         return telemedChatRepository.findByRoomId(roomId).orElseThrow(()-> new TelemedException(ROOM_NOT_FOUND));
-
     }
 
     private Summary findSummaryOrElse(String roomId){


### PR DESCRIPTION
## 🪺 PR 개요
진료 요약 api를 2번 호출 시 두 번째 호출에서 500 서버 에러가 발생하는 상황.
진료 종료 시 요약을 생성해서 db에 넣고, 진료 요약 조회 시 db에서 조회하도록 수정

## 🌱 Issue Number
- #82 

## ✨ 변경 사항
- [ ] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## 🙏 To Reviewers
>
