### PR TITLE
[BUG] 종료 api 호출 시 멱등화 설정

### DIFF
--- a/src/main/java/npng/handdoc/telemed/service/TelemedService.java
+++ b/src/main/java/npng/handdoc/telemed/service/TelemedService.java
@@ -74,7 +74,7 @@ public class TelemedService {
         assertParticipant(telemed, userId);
 
         if(telemed.getDiagnosisStatus() == DiagnosisStatus.ENDED){
-            throw new TelemedException(TelemedErrorCode.ALREADY_ROOM_ENDED);
+            return EndResponse.from(telemed);
         }
 
         telemed.markEnded();


### PR DESCRIPTION
## 🪺 PR 개요
- 종료 api 호출 시 한 명은 호출이 되지 않고 오류가 발생하는 상황에서 종료 api를 멱등화 시켜서 해결하였습니다. 

## 🌱 Issue Number
- #88

## ✨ 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## 🙏 To Reviewers
> 